### PR TITLE
Add property tests for simpler stuff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,7 +401,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -409,6 +418,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -439,6 +454,7 @@ dependencies = [
  "hmac",
  "object_store",
  "parquet",
+ "proptest",
  "ratatui",
  "regex",
  "reqwest 0.13.2",
@@ -992,9 +1008,15 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "regex",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdeflate"
@@ -2454,6 +2476,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+dependencies = [
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.11.0",
+ "num-traits",
+ "rand 0.9.1",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quick-xml"
 version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2576,6 +2623,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2968,6 +3024,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3305,6 +3373,19 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.1",
+ "once_cell",
+ "rustix 1.1.3",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3670,6 +3751,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3770,6 +3857,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,6 @@ serde_json = "1.0"
 parquet = "58"
 arrow = "58"
 bytes = "1.11"
+
+[dev-dependencies]
+proptest = "1.9"

--- a/src/app.rs
+++ b/src/app.rs
@@ -2551,6 +2551,54 @@ mod tests {
     use crate::event::EventHandler;
     use crate::preview::{ParquetSchemaPreview, PreviewData, PreviewFileType, TablePreview};
     use crate::terminal_icons::detect_terminal_icons;
+    use chrono::{TimeZone, Utc};
+    use proptest::prelude::*;
+    use std::collections::BTreeMap;
+
+    fn arb_entry_kind() -> impl Strategy<Value = super::EntryKind> {
+        prop_oneof![Just(super::EntryKind::File), Just(super::EntryKind::Folder)]
+    }
+
+    fn arb_sort_criteria() -> impl Strategy<Value = SortCriteria> {
+        prop_oneof![
+            Just(SortCriteria::Name),
+            Just(SortCriteria::DateModified),
+            Just(SortCriteria::DateCreated),
+            Just(SortCriteria::Size),
+        ]
+    }
+
+    fn arb_timestamp() -> impl Strategy<Value = Option<chrono::DateTime<chrono::Utc>>> {
+        prop::option::of((-2_208_988_800_i64..4_102_444_800_i64).prop_map(|secs| {
+            Utc.timestamp_opt(secs, 0)
+                .single()
+                .expect("generated timestamp should be valid")
+        }))
+    }
+
+    fn arb_file_item() -> impl Strategy<Value = super::FileItem> {
+        (
+            "[A-Za-z0-9_./-]{1,16}",
+            arb_entry_kind(),
+            prop::option::of(0_u64..10_000),
+            arb_timestamp(),
+            arb_timestamp(),
+        )
+            .prop_map(|(actual_name, kind, size, last_modified, created)| {
+                let icon = match kind {
+                    super::EntryKind::File => "[FILE]",
+                    super::EntryKind::Folder => "[DIR]",
+                };
+                super::FileItem {
+                    display_name: format!("{icon} {actual_name}"),
+                    actual_name,
+                    kind,
+                    size,
+                    last_modified,
+                    created,
+                }
+            })
+    }
 
     fn test_app() -> App {
         App {
@@ -2879,5 +2927,136 @@ mod tests {
         }
 
         assert_eq!(app.preview_scroll.1, 2);
+    }
+
+    proptest! {
+        #[test]
+        fn apply_sort_preserves_items_and_folders_stay_first(
+            items in prop::collection::vec(arb_file_item(), 0..40),
+            criteria in arb_sort_criteria(),
+        ) {
+            let mut sorted = items.clone();
+            App::sort_file_items_static(&mut sorted, criteria);
+
+            prop_assert_eq!(sorted.len(), items.len());
+
+            type ItemKey = (
+                String,
+                String,
+                bool,
+                Option<u64>,
+                Option<chrono::DateTime<chrono::Utc>>,
+                Option<chrono::DateTime<chrono::Utc>>,
+            );
+
+            let before = items.iter().fold(BTreeMap::<ItemKey, usize>::new(), |mut acc, item| {
+                *acc.entry((
+                    item.display_name.clone(),
+                    item.actual_name.clone(),
+                    matches!(item.kind, EntryKind::Folder),
+                    item.size,
+                    item.last_modified,
+                    item.created,
+                )).or_default() += 1_usize;
+                acc
+            });
+
+            let after = sorted
+                .iter()
+                .fold(BTreeMap::<ItemKey, usize>::new(), |mut acc, item| {
+                *acc.entry((
+                    item.display_name.clone(),
+                    item.actual_name.clone(),
+                    matches!(item.kind, EntryKind::Folder),
+                    item.size,
+                    item.last_modified,
+                    item.created,
+                ))
+                .or_default() += 1_usize;
+                    acc
+                });
+
+            prop_assert_eq!(before, after);
+
+            let first_file = sorted.iter().position(|item| item.kind == EntryKind::File);
+            if let Some(first_file) = first_file {
+                prop_assert!(sorted[first_file..].iter().all(|item| item.kind == EntryKind::File));
+            }
+        }
+
+        #[test]
+        fn apply_file_search_keeps_subset_and_resets_selection(
+            items in prop::collection::vec(arb_file_item(), 0..30),
+            query in "[A-Za-z0-9_./-]{0,8}",
+        ) {
+            let mut app = test_app();
+            let all_files: Vec<String> = items.iter().map(|item| item.display_name.clone()).collect();
+
+            app.session = Session::Browsing(BrowsingState {
+                object_store: std::sync::Arc::new(object_store::memory::InMemory::new()),
+                current_path: String::new(),
+                files: all_files.clone(),
+                file_items: items.clone(),
+                selected_index: 5,
+            });
+            app.search = Search::Files {
+                query: query.clone(),
+                all_files: all_files.clone(),
+                all_file_items: items.clone(),
+            };
+
+            app.apply_file_search(&query);
+
+            let Session::Browsing(state) = &app.session else {
+                prop_assert!(false, "expected browsing session");
+                return Ok(());
+            };
+
+            prop_assert_eq!(state.selected_index, 0);
+            prop_assert_eq!(
+                state.files.clone(),
+                state.file_items.iter().map(|item| item.display_name.clone()).collect::<Vec<_>>()
+            );
+
+            if query.is_empty() {
+                prop_assert_eq!(state.file_items.len(), items.len());
+            } else {
+                let lowered = query.to_lowercase();
+                prop_assert!(state.file_items.iter().all(|item| item.actual_name.to_lowercase().contains(&lowered)));
+                prop_assert!(state.file_items.len() <= items.len());
+            }
+        }
+
+        #[test]
+        fn preview_horizontal_scroll_stays_within_table_bounds(
+            cols in 0_usize..12,
+            moves in 0_usize..32,
+        ) {
+            let mut app = test_app();
+            app.preview_data = Some(PreviewData::Table(TablePreview {
+                headers: (0..cols).map(|i| format!("col{i}")).collect(),
+                column_types: None,
+                rows: if cols == 0 {
+                    Vec::new()
+                } else {
+                    vec![(0..cols).map(|i| format!("v{i}")).collect()]
+                },
+                total_rows: 1,
+                truncated: false,
+                file_type: PreviewFileType::Csv,
+            }));
+
+            for _ in 0..moves {
+                app.preview_scroll_right();
+            }
+
+            prop_assert!(app.preview_scroll.1 <= cols.saturating_sub(1));
+
+            for _ in 0..moves {
+                app.preview_scroll_left();
+            }
+
+            prop_assert_eq!(app.preview_scroll.1, 0);
+        }
     }
 }

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -777,6 +777,25 @@ fn format_parquet_type(field: &parquet::schema::types::Type) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
+
+    fn arb_json_value() -> impl Strategy<Value = serde_json::Value> {
+        let leaf = prop_oneof![
+            Just(serde_json::Value::Null),
+            any::<bool>().prop_map(serde_json::Value::Bool),
+            any::<i64>().prop_map(|n| serde_json::Value::Number(n.into())),
+            "[ -~]{0,32}".prop_map(serde_json::Value::String),
+        ];
+
+        leaf.prop_recursive(4, 64, 8, |inner| {
+            prop_oneof![
+                prop::collection::vec(inner.clone(), 0..8).prop_map(serde_json::Value::Array),
+                prop::collection::btree_map("[A-Za-z0-9_]{1,8}", inner, 0..8).prop_map(|entries| {
+                    serde_json::Value::Object(serde_json::Map::from_iter(entries))
+                }),
+            ]
+        })
+    }
 
     #[test]
     fn test_file_type_detection() {
@@ -1064,5 +1083,53 @@ mod tests {
 
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Failed to read Parquet"));
+    }
+
+    proptest! {
+        #[test]
+        fn make_valid_utf8_always_returns_valid_utf8(
+            data in prop::collection::vec(any::<u8>(), 0..1024)
+        ) {
+            let text = make_valid_utf8(&data);
+            prop_assert!(std::str::from_utf8(text.as_bytes()).is_ok());
+        }
+
+        #[test]
+        fn parse_json_handles_arbitrary_valid_json(value in arb_json_value()) {
+            let data = serde_json::to_vec(&value).expect("serializing generated JSON should succeed");
+            let preview = parse_json(&data).expect("valid JSON input should parse");
+
+            match preview {
+                PreviewData::Table(table) => {
+                    prop_assert_eq!(table.file_type, PreviewFileType::Json);
+                    prop_assert!(table.rows.len() <= MAX_PREVIEW_ROWS);
+                    prop_assert!(table.total_rows >= table.rows.len());
+                    prop_assert!(table.rows.iter().all(|row| row.len() == table.headers.len()));
+                }
+                PreviewData::Json(json) => {
+                    let visible_lines = json.content.lines().count();
+                    prop_assert!(json.total_lines >= visible_lines);
+                    if !json.truncated {
+                        prop_assert_eq!(json.total_lines, visible_lines);
+                    }
+                }
+                other => prop_assert!(false, "unexpected preview variant: {other:?}"),
+            }
+        }
+
+        #[test]
+        fn parse_preview_for_unknown_extension_only_yields_text_or_error(
+            data in prop::collection::vec(any::<u8>(), 0..2048)
+        ) {
+            let result = parse_preview(&data, &PreviewFileType::Unsupported);
+            match result {
+                Ok(PreviewData::Text(text)) => {
+                    prop_assert_eq!(text.extension, "TEXT");
+                    prop_assert!(std::str::from_utf8(text.content.as_bytes()).is_ok());
+                }
+                Ok(other) => prop_assert!(false, "unexpected preview variant: {other:?}"),
+                Err(_) => {}
+            }
+        }
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1733,7 +1733,8 @@ fn format_number(n: u64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::compute_table_column_viewport;
+    use super::{App, compute_table_column_viewport, truncate_with_ellipsis};
+    use proptest::prelude::*;
 
     #[test]
     fn viewport_marks_left_and_right_overflow() {
@@ -1761,5 +1762,29 @@ mod tests {
         assert_eq!(viewport.visible_indices, vec![2]);
         assert!(viewport.has_left_overflow);
         assert!(!viewport.has_right_overflow);
+    }
+
+    proptest! {
+        #[test]
+        fn footer_height_stays_in_expected_bounds(text in ".*", width in any::<u16>()) {
+            let height = App::calculate_footer_height(&text, width);
+            prop_assert!((3..=6).contains(&height));
+            if width <= 4 {
+                prop_assert_eq!(height, 3);
+            }
+        }
+
+        #[test]
+        fn ellipsis_truncation_respects_requested_limits(input in ".*", max_chars in 0_usize..32) {
+            let truncated = truncate_with_ellipsis(&input, max_chars);
+            if input.chars().count() <= max_chars {
+                prop_assert_eq!(truncated, input);
+            } else if max_chars <= 3 {
+                prop_assert_eq!(truncated, "...");
+            } else {
+                prop_assert!(truncated.chars().count() <= max_chars);
+                prop_assert!(truncated.ends_with("..."));
+            }
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces extensive property-based testing across multiple modules to improve test coverage and robustness. By leveraging the `proptest` crate, it ensures that key functionalities behave correctly under a wide variety of input scenarios, including edge cases that may not be covered by traditional unit tests. The changes also add new test utilities and strategies for generating complex test data.

**Testing improvements:**

* Added `proptest` as a development dependency in `Cargo.toml` to enable property-based testing throughout the codebase.

* In `src/app.rs`:
  - Introduced property-based tests for file sorting, file search, and preview scrolling logic, ensuring correctness and invariants (e.g., folders stay first, search results are subsets, scroll bounds are respected). Custom strategies for generating file items and sort criteria are included. [[1]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020R2554-R2601) [[2]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020R2931-R3061)

* In `src/preview.rs`:
  - Added property-based tests for UTF-8 conversion, JSON parsing, and previewing unknown file types, using a custom strategy to generate arbitrary JSON values. This validates that parsing and preview logic is robust against diverse and random data. [[1]](diffhunk://#diff-6650cb926fcaab52e46d5580416c1aee54ddea240b47f7a7c4f970e943e1cedbR780-R798) [[2]](diffhunk://#diff-6650cb926fcaab52e46d5580416c1aee54ddea240b47f7a7c4f970e943e1cedbR1087-R1134)

* In `src/ui.rs`:
  - Introduced property-based tests for footer height calculation and ellipsis truncation, ensuring these UI functions behave as expected for any string input and width. [[1]](diffhunk://#diff-acf9ca25b7b2d13e11c1035ebbda4140466603739b73a371b67a9a267d0ce626L1736-R1737) [[2]](diffhunk://#diff-acf9ca25b7b2d13e11c1035ebbda4140466603739b73a371b67a9a267d0ce626R1766-R1789)